### PR TITLE
Suggestion: Split long homepage content into separate dedicated pages for better structure #42

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,85 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="icon" href="./favicon.ico" type="image/x-icon">
+
+    <link href="./assets/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="./assets/css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+</head>
+<body>
+    <style>
+  body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+  }
+  nav {
+    background-color: #333;
+    padding: 0 20px;
+  }
+  nav ul {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    list-style: none;
+  }
+  nav ul li {
+    margin: 0;
+  }
+  nav ul li a {
+    display: block;
+    padding: 14px 20px;
+    text-decoration: none;
+    color: white;
+    transition: background 0.3s;
+  }
+  nav ul li a:hover {
+    background-color: #575757;
+  }
+</style>
+
+    <nav>
+  <ul>
+    <li><a href="index.html">Home</a></li>
+    <li><a href="about.html">About</a></li>
+    <li><a href="achivements.html">Achievement</a></li>
+    <li><a href="team.html">Team</a></li>
+    <li><a href="partners.html">Partner</a></li>
+    <li><a href="testimonial.html">Testimonials</a></li>
+    <li><a href="why gurkul.html">Why Gurkul</a></li>
+    
+  </ul>
+</nav>
+            <div class="py-2 py-md-0"></div>
+        </div>
+
+        <div class="Our-Work mb-5 mt-5 overflow-x-hidden">
+            <div class="container text-start overflow-x-hidden">
+                <div style="column-gap: 0px !important;" class=" d-flex  flex-column flex-md-row justify-content-center align-items-md-start gap-3 align-items-center">
+                    <div class="mx-5 about-gurukul-img">
+                        <img src="./assets/images/aboutGurukul.jpeg"
+                            class="rounded shadow about-gurukul-img" style="width: 500px; height: 250px" alt="..." />
+                    </div>
+                    <div style="" class=" d-flex flex-column justify-content-start  ">
+                        <h1 class="mt-0 mt-md-0  display-4 libre-baskerville-regular">About Gurukul</h1>
+                        <p class="w-100 founders-message-data" style="text-align: justify; font-size: x-large;">
+                        Welcome to Gurukul Dream Foundation, where we empower the youth of tier 2/3 cities. Our goal is to provide tailored support and opportunities for young individuals to thrive. Through workshops, internships, and more, we aim to equip them with the skills they need to succeed. Join us as we shape a brighter future for every aspiring young mind.
+                        </p>
+                        <!-- <button type="button" style="width: 150px" class="btn btn-dark mt-md-3 mt-1">
+                            Read More
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                                class="bi bi-arrow-right" viewBox="0 0 16 16">
+                                <path fill-rule="evenodd"
+                                    d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8" />
+                            </svg>
+                        </button> -->
+                    </div>
+                </div>
+            </div>
+        </div>
+</body>
+</html>

--- a/achivements.html
+++ b/achivements.html
@@ -1,0 +1,164 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="icon" href="./favicon.ico" type="image/x-icon">
+
+    <link href="./assets/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="./assets/css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+</head>
+
+
+<body>
+    <style>
+  body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+  }
+  nav {
+    background-color: #333;
+    padding: 0 20px;
+  }
+  nav ul {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    list-style: none;
+  }
+  nav ul li {
+    margin: 0;
+  }
+  nav ul li a {
+    display: block;
+    padding: 14px 20px;
+    text-decoration: none;
+    color: white;
+    transition: background 0.3s;
+  }
+  nav ul li a:hover {
+    background-color: #575757;
+  }
+</style>
+
+    <nav>
+  <ul>
+    <li><a href="index.html">Home</a></li>
+    <li><a href="about.html">About</a></li>
+    <li><a href="achivements.html">Achievement</a></li>
+    <li><a href="team.html">Team</a></li>
+    <li><a href="partners.html">Partner</a></li>
+    <li><a href="testimonial.html">Testimonials</a></li>
+    <li><a href="why gurkul.html">Why Gurkul</a></li>
+    
+  </ul>
+</nav>
+    <div
+            class="w-100 reached-numbers bg-yellow text-white d-flex flex-column flex-lg-row flex-wrap justify-content-evenly align-items-center px-2 py-0 " id="Our-Achievements">
+            <div class="  text-center h2 p-4 rounded mt-2 text-wrap libre-baskerville-regular">
+                <span class="text-danger">Our </span>
+                <span class="text-black">Achievements</span>
+            </div>
+            <div
+                class="all-reached-data d-flex justify-content-evenly align-items-center flex-md-nowrap flex-wrap gap-md-4 gap-1   px-md-0 px-lg-2 py-0 ">
+
+                <div
+                    class="bg-yellow  reached-numbers-boxes w-100 p-3 py-2 text-center d-flex flex-column align-items-center justify-content-start ">
+                    <div class="inner w-100 pt-3">  <img class="w-50 our-reach-icons-images" style="width: 60px !important;" src="./assets/images/reach/events-logo.png" alt=""></div>
+                    <div class="number-box">
+
+                        <div class="reached-nums-data fs-2 text-black"  data-reachedNumFinally="10+" data-reachedNum="10">
+                            0
+                        </div>
+                        <div class="reached-nums-about text-danger fw-bold small">
+                            District Level Events
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="bg-yellow  reached-numbers-boxes w-100 px-3 py-4 py-1  text-center d-flex flex-column align-items-center justify-content-start ">
+                    <div class="inner "> <img class="w-50 our-reach-icons-images" style="width: 60px !important;" src="./assets/images/reach/session-logo.png" alt=""></div>
+                    <div class="number-box">
+
+                        <div class="reached-nums-data fs-2 text-black"  data-reachedNumFinally="20+" data-reachedNum="20">
+                            0
+                        </div>
+                        <div class="reached-nums-about text-danger fw-bold small">
+                            Startup Summits/ Sessions
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="bg-yellow  reached-numbers-boxes w-100 p-3 py-4 text-center d-flex flex-column align-items-center justify-content-start ">
+                    <div class="inner w-100"> <img class="w-50 our-reach-icons-images" style="width: 60px !important;" src="./assets/images/reach/workshop.png" alt=""></div>
+                    <div class="number-box">
+                        
+                        <div class="reached-nums-data fs-2 text-black"  data-reachedNumFinally="80+" data-reachedNum="80">
+                            0
+                        </div>
+                        <div class="reached-nums-about text-danger fw-bold small">
+                            Workshops
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="bg-yellow  reached-numbers-boxes w-100 p-3 py-4 text-center d-flex flex-column align-items-center justify-content-start ">
+                    <div class="inner w-100"> <img class="w-50 our-reach-icons-images" style="width: 60px !important;" src="./assets/images/reach/industry.png" alt=""></div>
+                    <div class="number-box">
+
+                        <div class="reached-nums-data fs-2 text-black"  data-reachedNumFinally="15+" data-reachedNum="15">
+                            0
+                        </div>
+                        <div class="reached-nums-about text-danger fw-bold small">
+                            Industry Visits
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="bg-yellow  reached-numbers-boxes w-100 p-3 py-4 text-center d-flex flex-column align-items-center justify-content-start ">
+                    <div class="inner w-100">  <img class="w-50 our-reach-icons-images" style="width: 60px !important;" src="./assets/images/reach/jobs.png" alt=""></div>
+                    <div class="number-box">
+
+                        <div class="reached-nums-data fs-2 text-black"  data-reachedNumFinally="60+" data-reachedNum="60">
+                            0
+                        </div>
+                        <div class="reached-nums-about text-danger fw-bold small">
+                            Jobs provided
+                            
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="bg-yellow  reached-numbers-boxes w-100 p-3 py-4 text-center d-flex flex-column align-items-center justify-content-start">
+                    <div class="inner w-100"> <img class="w-50 our-reach-icons-images" style="width: 60px !important;" src="./assets/images/reach/internship.png" alt=""> </div>
+                    <div class="number-box">
+
+                        <div class="reached-nums-data fs-2 text-black"  data-reachedNumFinally="100+" data-reachedNum="100">
+                            0
+                        </div>
+                        <div class="reached-nums-about text-danger fw-bold small">
+                            Internships provided
+                            
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="bg-yellow  reached-numbers-boxes w-100 p-3 text-center d-flex flex-column align-items-center justify-content-start ">
+                    <div class="inner w-100"> <img class="w-50 our-reach-icons-images pt-2 pt-sm-1 pt-md-3" style="width: 50px !important;" src="./assets/images/reach/counciling.png" alt=""></div>
+                    <div class="number-box">
+                        <div class="reached-nums-data fs-2 text-black pt-1"  data-reachedNumFinally="10,000+" data-reachedNum="10000">
+                            0
+                        </div>
+                        <div class="reached-nums-about text-danger fw-bold small">
+                        Students Counseled through "Safarnama"
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="py-2 py-md-0"></div>
+        </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,49 @@
 
 <body class="overflow-x-hidden">
     <div id="header"></div>
+    <!-- Navbar Start -->
+<style>
+  body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+  }
+  nav {
+    background-color: #333;
+    padding: 0 20px;
+  }
+  nav ul {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    list-style: none;
+  }
+  nav ul li {
+    margin: 0;
+  }
+  nav ul li a {
+    display: block;
+    padding: 14px 20px;
+    text-decoration: none;
+    color: white;
+    transition: background 0.3s;
+  }
+  nav ul li a:hover {
+    background-color: #575757;
+  }
+</style>
+
+<nav>
+  <ul>
+    <li><a href="about.html">About</a></li>
+    <li><a href="achivements.html">Achievement</a></li>
+    <li><a href="team.html">Team</a></li>
+    <li><a href="partners.html">Partner</a></li>
+    <li><a href="testimonial.html">Testimonials</a></li>
+    <li><a href="why gurkul.html">Why Gurkul</a></li>
+    
+  </ul>
+</nav>
+<!-- Navbar End -->
 
     <main class="container-auto ">
         <!-- image slider section -->

--- a/partners.html
+++ b/partners.html
@@ -1,0 +1,91 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="icon" href="./favicon.ico" type="image/x-icon">
+
+    <link href="./assets/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="./assets/css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+
+</head>
+<body>
+    <style>
+  body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+  }
+  nav {
+    background-color: #333;
+    padding: 0 20px;
+  }
+  nav ul {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    list-style: none;
+  }
+  nav ul li {
+    margin: 0;
+  }
+  nav ul li a {
+    display: block;
+    padding: 14px 20px;
+    text-decoration: none;
+    color: white;
+    transition: background 0.3s;
+  }
+  nav ul li a:hover {
+    background-color: #575757;
+  }
+</style>
+
+    <nav>
+  <ul>
+    <li><a href="index.html">Home</a></li>
+    <li><a href="about.html">About</a></li>
+    <li><a href="achivements.html">Achievement</a></li>
+    <li><a href="team.html">Team</a></li>
+    <li><a href="partners.html">Partner</a></li>
+    <li><a href="testimonial.html">Testimonials</a></li>
+    <li><a href="why gurkul.html">Why Gurkul</a></li>
+    
+  </ul>
+</nav>
+    <div class="my-1 py-2"></div>
+        <h2 class="text-center libre-baskerville-regular">Our Partners</h2>
+        <div class="container px-2 our-parteners-section  overflow-x-hidden">
+            <marquee behavior="scroll" direction="left" class="py-2 px-1 ">
+                <img src="assets/images/college-logoes/1.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/2.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/3.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/4.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/5.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/6.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/7.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/8.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/9.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/10.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/11.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/12.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+                <img src="assets/images/college-logoes/13.png"
+                    alt="our-partners-images" class="rounded shadow border border-dark px-5 mx-3 py-0 " width="200">
+            </marquee>
+        </div>
+</body>
+</html>

--- a/team.html
+++ b/team.html
@@ -1,0 +1,169 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="icon" href="./favicon.ico" type="image/x-icon">
+
+    <link href="./assets/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="./assets/css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+</head>
+<body>
+            <nav><style>
+  body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+  }
+  nav {
+    background-color: #333;
+    padding: 0 20px;
+  }
+  nav ul {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    list-style: none;
+  }
+  nav ul li {
+    margin: 0;
+  }
+  nav ul li a {
+    display: block;
+    padding: 14px 20px;
+    text-decoration: none;
+    color: white;
+    transition: background 0.3s;
+  }
+  nav ul li a:hover {
+    background-color: #575757;
+  }
+</style>
+
+  <ul>
+    <li><a href="index.html">Home</a></li>
+    <li><a href="about.html">About</a></li>
+    <li><a href="achivements.html">Achievement</a></li>
+    <li><a href="team.html">Team</a></li>
+    <li><a href="partners.html">Partner</a></li>
+    <li><a href="testimonial.html">Testimonials</a></li>
+    <li><a href="why gurkul.html">Why Gurkul</a></li>
+    
+  </ul>
+</nav>            
+
+
+        <div class="container-fluid bg-white text-center Testimonials overflow-x-hidden  pt-2 pb-5 " id="The-Team">
+            <h2 class="text-green h1 libre-baskerville-regular">Active Members</h2>
+            <br>            
+            
+            <marquee behaviour="scroll" direction="left" id="our-Team-member-section" class="d-flex  overflow-x-hidden justify-content-center md-3 gap-5">
+            <div style="row-gap: 10px;"  class="our-Team-member-section d-flex justify-content-center align-items-beween">
+            
+                    
+                    <div style="width: 200px;" class="col mx-3">
+                        <div class="card w-100 text-white  d-flex flex-column align-items-center justify-content-center bg-success" style="padding: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 150px;"
+                                    src="./assets/images/members/himanshu.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body text-center">
+                                <b>Himanshu Agrawal</b>
+                                <!-- <p>Frontend Developer</p> -->
+                            </div>
+                        </div>
+                    </div>
+                    <div style="width: 200px;" class="col mx-3">
+                        <div class="card w-100 text-white  bg-success d-flex flex-column align-items-center justify-content-center" style="padding: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 150px;"
+                                    src="./assets/images/members/jyesh.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body text-center">
+                                
+                                <b>Jayesh Shrivastava</b>
+                                <!-- <p>Frontend Developer</p> -->
+                            </div>
+                        </div>
+                    </div>
+                    <div style="width: 200px;" class="col mx-3">
+                        <div class="card w-100 text-white  d-flex bg-success flex-column align-items-center justify-content-center" style="padding: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 150px;"
+                                    src="./assets/images/members/aparna.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body text-center">
+                                <!-- <br> -->
+                                <b>Aparna Sharma</b>
+                                <!-- <p>Frontend Developer</p> -->
+                            </div>
+                        </div>
+                    </div>
+                    <div style="width: 200px;" class="col mx-3">
+                        <div class="card w-100 text-white  d-flex flex-column align-items-center justify-content-center bg-success" style="padding: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 150px;"
+                                    src="./assets/images/members/arpit.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body text-center">
+                                <!-- <br> -->
+                                <b>Arpit Gupta</b>
+                                <!-- <p>Frontend Developer</p> -->
+                            </div>
+                        </div>
+                    </div>
+                    <div style="width: 200px;" class="col mx-3">
+                        <div class="card w-100 text-white  bg-success d-flex flex-column align-items-center justify-content-center" style="padding: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 150px;"
+                                    src="./assets/images/members/mohit.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body text-center">
+                                <!-- <br> -->
+                                <b>Mohit Singh</b>
+                                <!-- <p>Frontend Developer</p> -->
+                            </div>
+                        </div>
+                    </div>
+                    <!-- <div style="width: 200px;" class="col mx-3">
+                        <div class="card w-100 text-white d-flex bg-success flex-column align-items-center justify-content-center" style="padding: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 150px;"
+                                    src="./assets/images/members/akash.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body text-center">
+                                 <br> 
+                                <b>Akash Barua</b>
+                                 <p>Frontend Developer</p>
+                            </div>
+                        </div>
+                    </div> -->
+                    <div style="width: 320px;" class="col mx-3">
+                        <div class="card w-100 text-white d-flex bg-success flex-column align-items-center justify-content-evenly" style="padding: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 150px;"
+                                    src="./assets/images/members/anshul.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body text-center">
+                                <!-- <br> -->
+                                <b>Anshul Mishra</b>
+                                <!-- <p>Frontend Developer</p> -->
+                            </div>
+                        </div>
+                    </div>
+                </div>             
+            </marquee> 
+        </div>
+        
+
+</body>
+</html>

--- a/testimonial.html
+++ b/testimonial.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Testimonials</title>
+    
+    <link rel="icon" href="./favicon.ico" type="image/x-icon">
+
+    <link href="./assets/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="./assets/css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+</head>
+<body>
+<div id="header"></div>
+    <nav><style>
+  body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+  }
+  nav {
+    background-color: #333;
+    padding: 0 20px;
+  }
+  nav ul {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    list-style: none;
+  }
+  nav ul li {
+    margin: 0;
+  }
+  nav ul li a {
+    display: block;
+    padding: 14px 20px;
+    text-decoration: none;
+    color: white;
+    transition: background 0.3s;
+  }
+  nav ul li a:hover {
+    background-color: #575757;
+  }
+</style>
+
+  <ul>
+    <li><a href="index.html">Home</a></li>
+    <li><a href="about.html">About</a></li>
+    <li><a href="achivements.html">Achievement</a></li>
+    <li><a href="team.html">Team</a></li>
+    <li><a href="partners.html">Partner</a></li>
+    <li><a href="testimonial.html">Testimonials</a></li>
+    <li><a href="why gurkul.html">Why Gurkul</a></li>
+    
+  </ul>
+</nav>
+
+    <div class="container  text-center Testimonials overflow-x-hidden mt-5">
+            <h2 class="text-black h1 libre-baskerville-regular">Testimonials</h2>
+            <br>
+            
+            
+            <div style="row-gap: 10px;"  class="testimonials-section  d-flex justify-content-center align-items-beween">
+            
+                <div id="testimonials-section" class="d-flex  justify-content-center md-3 gap-5">
+                    
+                    <div style="width: 320px;" class="col ">
+                        <div class="card w-100 shadow-yellow text-white bg-dark " style="padding-top: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 100px;"
+                                    src="./assets/images/testimonials/abhiraj.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body">
+                                <h5 class="card-title">
+                                    <h5 class="card-title my-0 py-0"><svg xmlns="http://www.w3.org/2000/svg" width="30" height="30"
+                                            fill="currentColor" class="bi bi-quote" viewBox="0 0 16 16">
+                                            <path
+                                                d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z" />
+                                        </svg></h5>
+                                </h5>
+                                <p class="d-flex text-justify mt-0"><i>"Gurukul made a huge difference in my life! The workshops boosted my confidence, and the career guidance helped me find my path. Now, I feel ready for my career journey, all thanks to Gurukul!"</i>
+</p>
+                                <b>Abhiraj Sahu </b>
+                                <p><span>Student
+ @ </span> Maharaja Mansingh College</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div style="width: 320px;" class="col ">
+                        <div class="card w-100 shadow-yellow text-white bg-dark " style="padding-top: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 100px;"
+                                    src="./assets/images/testimonials/aryan.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body">
+                                <h5 class="card-title py-0 my-0">
+                                    <h5 class="card-title py-0 my-0"><svg xmlns="http://www.w3.org/2000/svg" width="30" height="30"
+                                            fill="currentColor" class="bi bi-quote" viewBox="0 0 16 16">
+                                            <path
+                                                d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z" />
+                                        </svg></h5>
+                                </h5>
+                                <p class="card-text text-justify mt-0"><i>"Gurukul gave me the tools I needed to succeed. Through internships and mentorship, I gained valuable skills and experience. Now, I'm confident and prepared for whatever comes next. Thanks, Gurukul!"</i></p>
+                                
+                                <b>Aryan Sahu 
+</b>
+                                <p> <span>Student @ </span>  
+Amity University</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div style="width: 320px;" class="col">
+                        <div class="card w-100 text-white shadow-yellow bg-dark " style="padding-top: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 100px;"
+                                    src="./assets/images/testimonials/kumkum.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body">
+                                <h5 class="card-title">
+                                    <h5 class="card-title py-0 my-0"><svg xmlns="http://www.w3.org/2000/svg" width="30" height="30"
+                                            fill="currentColor" class="bi bi-quote" viewBox="0 0 16 16">
+                                            <path
+                                                d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z" />
+                                        </svg></h5>
+                                </h5>
+                                <p class="card-text text-justify mt-0"><i>"Gurukul has been my guiding light through college. The industrial visits and job support paved the way for my career journey. Now, I'm ready to tackle the world with confidence, thanks to Gurukul!"</i></p>
+                             
+                                <b>Kumkum Jha </b>
+                                <p> <span>Student @ </span>  J.C mill College</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div style="width: 320px;" class="col">
+                        <div class="card w-100 text-white shadow-yellow bg-dark " style="padding-top: 10px !important; width: 18rem;">
+                            <div>
+                                <img style="border-radius: 50%; width: 100px;"
+                                    src="./assets/images/testimonials/sakshi.jpg"
+                                    class="card-img-top" alt="...">
+                            </div>
+                            <div class="card-body">
+                                <h5 class="card-title">
+                                    <h5 class="card-title py-0 my-0"><svg xmlns="http://www.w3.org/2000/svg" width="30" height="30"
+                                            fill="currentColor" class="bi bi-quote" viewBox="0 0 16 16">
+                                            <path
+                                                d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z" />
+                                        </svg></h5>
+                                </h5>
+                                <p class="card-text text-justify mt-0"><i>"Gurukul has been a lifeline during my college years. The mental health support and networking opportunities helped me stay balanced and connected. Now, I'm excited about my future career, all thanks to Gurukul!"
+</i></p>
+                                <b>Sakshi Bhadouriya
+</b>
+ <p> <span>Student @ </span> KRG College</p>
+                            
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                
+            </div>                                  
+            
+            </button>
+            <button class="btn btn-left my-2 mx-2" id="testimonial-btn-left">
+            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-caret-left-fill" viewBox="0 0 16 16">
+            <path d="m3.86 8.753 5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z"/>
+            </svg>
+        </button>
+            <button class="btn btn-right my-2 mx-2" id="testimonial-btn-right">
+                <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-caret-right-fill" viewBox="0 0 16 16">
+                <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
+                </svg>
+            </button>
+            
+        </div>
+        
+    <script src="./assets/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="./assets/js/script.js"></script>
+    <script>
+    // Dynamically load the header and footer from PHP files
+    const loadComponent = (selector, url) => {
+      fetch(url)
+        .then(res => {
+          if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
+          return res.text();
+        })
+        .then(html => {
+          document.querySelector(selector).innerHTML = html;
+        })
+        .catch(err => {
+          console.error(`Could not load ${url}:`, err);
+        });
+    };
+
+    loadComponent('#header', '_header.html');
+    loadComponent('#footer', '_footer.html');
+  </script>
+         
+</body>
+</html>

--- a/why gurkul.html
+++ b/why gurkul.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="icon" href="./favicon.ico" type="image/x-icon">
+
+    <link href="./assets/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="./assets/css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+</head>
+<body>
+    <style>
+  body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+  }
+  nav {
+    background-color: #333;
+    padding: 0 20px;
+  }
+  nav ul {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    list-style: none;
+  }
+  nav ul li {
+    margin: 0;
+  }
+  nav ul li a {
+    display: block;
+    padding: 14px 20px;
+    text-decoration: none;
+    color: white;
+    transition: background 0.3s;
+  }
+  nav ul li a:hover {
+    background-color: #575757;
+  }
+</style>
+
+    <nav>
+  <ul>
+    <li><a href="index.html">Home</a></li>
+    <li><a href="about.html">About</a></li>
+    <li><a href="achivements.html">Achievement</a></li>
+    <li><a href="team.html">Team</a></li>
+    <li><a href="partners.html">Partner</a></li>
+    <li><a href="testimonial.html">Testimonials</a></li>
+    <li><a href="why gurkul.html">Why Gurkul</a></li>
+    
+  </ul>
+</nav>
+    <div class="Key-contributions bg-dark text-center w-100 Key overflow-x-hidden" id="Why-Gurukul">
+        <div class="text-white h1 pb-1 pt-5 overflow-x-hidden libre-baskerville-regular">Why Gurukul?</div>
+            <div  class="flex-row flex-wrap flex-md-row w-100 d-flex overflow-x-hidden align-items-center px-2 gap-5 justify-content-center  pb-5">
+                <div  class="small mt-md-2 mt-lg-5 mt-sm-2 mt-0  why-gurukul-cards">
+                    <div style="width: 300px !important; height: 250px;" class="card why-gurukul-cards-responsive w-100 shadow-yellow" style="padding: 5px !important;">
+                        <div class="mt-lg-5 mt-sm-0">
+                            <img src="./assets/images/why-gurukul-logoes/workshop.png" alt="why gurukul logoes" class="w-25">
+                            <!-- <i class="fa-solid fa-book" style="font-size: 100px"></i> -->
+                        </div>
+                        <div class="card-body">
+                            <div class="card-text text-heading-small fw-bold fs-3">Workshops & Fun Events 
+</div>
+                        </div>
+                    </div>
+                </div>
+                <div  class="small mt-md-2 mt-lg-5 mt-sm-2 mt-0 why-gurukul-cards">
+                    <div style="width: 300px !important; height: 250px;" class="card why-gurukul-cards-responsive w-100 shadow-yellow" style="padding: 5px !important;">
+                        <div class="mt-lg-5 mt-sm-0">
+                            <img src="./assets/images/why-gurukul-logoes/internship.png" alt="why gurukul logoes" class="w-25">
+                        <!-- <i class="fa-solid fa-tv" style="font-size: 100px"></i> -->
+                        </div>
+                        <div class="card-body">
+                            <div class="card-text text-heading-small fw-bold fs-3">Internships & Job Opportunities</div>
+                        </div>
+                    </div>
+                </div>
+                <div  class="small mt-md-2 mt-lg-5 mt-sm-2 mt-0 why-gurukul-cards">
+                    <div style="width: 300px !important; height: 250px;" class="card why-gurukul-cards-responsive w-100 shadow-yellow" style="padding: 5px !important;">
+                        <div class="mt-lg-5 mt-sm-0">
+                            <img src="./assets/images/why-gurukul-logoes/counseling.jpg" alt="why gurukul logoes" class="w-25">
+                        <!-- <i class="fa-solid fa-arrow-up-right-dots" style="font-size: 100px"></i> -->
+                        </div>
+                        <div class="card-body">
+                            <div class="card-text text-heading-small fw-bold fs-3">Career & Education Counseling</div>
+                        </div>
+                    </div>
+                </div>
+                <div  class="small mt-md-2 mt-lg-5 mt-sm-2 mt-0  why-gurukul-cards">
+                    <div style="width: 300px !important; height: 250px;" class="card why-gurukul-cards-responsive w-100 shadow-yellow" style="padding: 5px !important;">
+                        <div class="mt-lg-5 mt-sm-0">
+                            <img src="./assets/images/why-gurukul-logoes/placement.jpg" alt="why gurukul logoes" class="w-25">
+                            <!-- <i class="fa-solid fa-book" style="font-size: 100px"></i> -->
+                        </div>
+                        <div class="card-body">
+                            <div class="card-text text-heading-small fw-bold fs-3">Placement & Training Support 
+</div>
+                        </div>
+                    </div>
+                </div>
+                <div  class="small mt-md-2 mt-lg-5 mt-sm-2 mt-0 why-gurukul-cards">
+                    <div style="width: 300px !important; height: 250px;" class="card why-gurukul-cards-responsive w-100 shadow-yellow" style="padding: 5px !important;">
+                        <div class="mt-lg-5 mt-sm-0">
+                            <img src="./assets/images/why-gurukul-logoes/industrial-visit.jpg" alt="why gurukul logoes" class="w-25">
+                        <!-- <i class="fa-solid fa-tv" style="font-size: 100px"></i> -->
+                        </div>
+                        <div class="card-body">
+                            <div class="card-text text-heading-small fw-bold fs-3">Industrial Visits
+</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="small mt-md-2 mt-lg-5 mt-sm-2 mt-0 why-gurukul-cards">
+                    <div style="width: 300px !important; height: 250px;"  class="card why-gurukul-cards-responsive w-100 shadow-yellow" style="padding: 5px !important;">
+                        <div class="mt-lg-5 mt-sm-0">
+                            <img src="./assets/images/why-gurukul-logoes/mental-health.jpg" alt="why gurukul logoes" class="w-25">
+                        <!-- <i class="fa-solid fa-arrow-up-right-dots" style="font-size: 100px"></i> -->
+                        </div>
+                        <div class="card-body">
+                            <div class="card-text text-heading-small fw-bold fs-3">Mental Health Support 
+</div>
+                        </div>
+                    </div>
+                </div>
+                <div  class="small mt-md-2 mt-lg-5 mt-sm-2 mt-0  why-gurukul-cards">
+                    <div style="width: 300px !important; height: 250px;" class="card why-gurukul-cards-responsive w-100 shadow-yellow" style="padding: 5px !important;">
+                        <div class="mt-lg-5 mt-sm-0">
+                            <img src="./assets/images/why-gurukul-logoes/networking.jpg" alt="why gurukul logoes" class="w-25">
+                            <!-- <i class="fa-solid fa-book" style="font-size: 100px"></i> -->
+                        </div>
+                        <div class="card-body">
+                            <div class="card-text text-heading-small fw-bold fs-3">Networking Opportunities</div>
+                        </div>
+                    </div>
+                </div>
+                <div  class="small mt-md-2 mt-lg-5 mt-sm-2 mt-0 why-gurukul-cards">
+                    <div style="width: 300px !important; height: 250px;" class="card why-gurukul-cards-responsive w-100 shadow-yellow" style="padding: 5px !important;">
+                        <div class="mt-lg-5 mt-sm-0">
+                            <img src="./assets/images/why-gurukul-logoes/adventure.jpg" alt="why gurukul logoes" class="w-25">
+                        <!-- <i class="fa-solid fa-tv" style="font-size: 100px"></i> -->
+                        </div>
+                        <div class="card-body">
+                            <div class="card-text text-heading-small fw-bold fs-3">Adventure Trips</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class=" py-2 bg-white"></div>
+<!-- 
+        <div class="Our-Work mb-5">
+            <div class="container text-start">
+                <div style="column-gap: 50px" class="row justify-content-start">
+                    <div style="" class="col-md-6 d-flex flex-column justify-content-center">
+                        <h1>Who we are</h1>
+                        <p>
+                        Muskaan Dreams is an award-winning, youth-driven non-profit organization incorporated in 2017. We believe in shaping dreams, and working through a collaboration model, value creativity and believe, digital access is a necessity rather than a luxury.
+                        </p>
+                        <button type="button" style="width: 150px" class="btn btn-dark mt-1 mt-md-3">
+                            Read More
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                                class="bi bi-arrow-right" viewBox="0 0 16 16">
+                                <path fill-rule="evenodd"
+                                    d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8" />
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="col-md-5 mt-3">
+                        <img src="https://muskaandreams.org/wp-content/uploads/2020/11/what-we-do.jpg"
+                            class="rounded shadow" style="width: 100%; height: 100%" alt="..." />
+                    </div>
+                </div>
+            </div>
+        </div> -->
+
+
+
+
+      
+
+
+
+<!-- 
+        <div class="my-1 py-2"></div>
+
+        <div class="donate bg-black text-white pt-5  pb-5 d-flex flex-column flex-md-row align-items-center">
+            <div class="donate-img" style="width : 50%;"><img src="assets/images/slider-images/1.jpg" alt="..." width="100%"></div>
+            <div class="donate-text fw-bold fs-2  text-center d-flex align-items-center flex-column justify-content-center w-75" style="width : 50%;">
+                <p>Donate any amount or gift.</p>
+                 <div><a href="./Donate.php" class="text-decoration-none bg-warning border rounded-pill text-dark p-2 px-3 fs-4">Donate Now</a></div>
+            </div>
+        </div> -->
+</body>
+</html>


### PR DESCRIPTION
As part of my contribution to GSSoC, I have refactored the long homepage into separate, dedicated pages to enhance user experience and maintainability.

Changes made:

Created About Us, Testimonials, Team, Achievements, and Why This Website, Partners

Updated the navigation bar to include links to these new pages

Ensured each page retains consistent styling and structure with the main site


This improvement makes the website cleaner, easier to navigate, and more modular for future contributions.

<img width="1920" height="1020" alt="Screenshot 2025-08-10 141717" src="https://github.com/user-attachments/assets/1441fa16-b61d-4737-9f68-3d6b3f878e1b" />
<img width="1920" height="1020" alt="Screenshot 2025-08-10 141727" src="https://github.com/user-attachments/assets/53eaf1df-2f69-43db-9a40-bcf2dc1bc028" />
<img width="1920" height="1020" alt="Screenshot 2025-08-10 141736" src="https://github.com/user-attachments/assets/d3f9621c-7447-43ee-882a-1307c4f76dbf" />
<img width="1920" height="1020" alt="Screenshot 2025-08-10 141803" src="https://github.com/user-attachments/assets/4421917a-2a1f-4ca0-b31b-ae6ee1687e1f" />
<img width="1920" height="1020" alt="Screenshot 2025-08-10 141827" src="https://github.com/user-attachments/assets/d16575f7-1044-4891-be0d-623312bfb59f" />
<img width="1920" height="1020" alt="Screenshot 2025-08-10 142213" src="https://github.com/user-attachments/assets/861799e2-4a2f-4779-acb5-a71fb7695cf5" />
<img width="1920" height="1020" alt="Screenshot 2025-08-10 144653" src="https://github.com/user-attachments/assets/29c4b348-fed3-4b1a-ae82-16234075e1d2" />
